### PR TITLE
fix autocomplete down arrow on the last item

### DIFF
--- a/src/packages/autocomplete/autocomplete.tsx
+++ b/src/packages/autocomplete/autocomplete.tsx
@@ -91,7 +91,7 @@ const Autocomplete = ({
     }
     // User pressed the down arrow
     else if (e.keyCode === 40) {
-      if (activeSuggestion - 1 === filteredSuggestions.length) {
+      if (activeSuggestion === filteredSuggestions.length - 1) {
         return;
       }
       setActiveSuggestion(activeSuggestion + 1);

--- a/src/packages/autocomplete/snippets/index.mdx
+++ b/src/packages/autocomplete/snippets/index.mdx
@@ -99,7 +99,7 @@ function Autocomplete({
     }
     // User pressed the down arrow
     else if (e.keyCode === 40) {
-      if (activeSuggestion - 1 === filteredSuggestions.length) {
+      if (activeSuggestion === filteredSuggestions.length - 1) {
         return;
       }
       setActiveSuggestion(activeSuggestion + 1);


### PR DESCRIPTION
Minor fix for autocomplete. When a user presses down on the last filteredSuggestions item, the selection disappears. This small change prevents that from happening